### PR TITLE
WIP: Initial extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM python:3.8
 COPY ./Makefile ./Makefile
 RUN make docker
 COPY ./ws_server.py ./ws_server.py
-EXPOSE 80
+EXPOSE 8081
 
 CMD [ "uwsgi", "/app/config.yml" ]

--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,5 @@
 # Eth2 API endpoint
-eth2_api: http://<IP>:<PORT>
+eth2_api: http://mainnet-lodestar-520_beacon_node_1:9596
 
 # Optional graffiti to display in your JSON response
 ws_server_graffiti: 
@@ -13,6 +13,6 @@ redis: redis
 # uwsgi server configuration
 uwsgi:
   wsgi: ws_server:app
-  http: 0.0.0.0:80
+  http: 0.0.0.0:8081
   processes: 1
   threads: 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,17 +5,15 @@ services:
     image: "redis"
     ports:
       - 6379
-    # network_mode: host
     networks:
-      - my-external-network
+      - ws_network
   eth2_ws_server:
     build:
       context: .
       dockerfile: Dockerfile
     image: "eth2_ws_server"
-    # network_mode: host
     networks:
-      - my-external-network
+      - ws_network
     volumes:
       - .:/app
     depends_on:
@@ -24,5 +22,6 @@ services:
       - "0.0.0.0:8081:8081"
 
 networks:
-  my-external-network:
+  # NOTE: this assumes that the user has already greated the ws_network and has also confiured the lodestar docker-compose.yml to use the same network
+  ws_network:
     external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,14 +5,24 @@ services:
     image: "redis"
     ports:
       - 6379
+    # network_mode: host
+    networks:
+      - my-external-network
   eth2_ws_server:
     build:
       context: .
       dockerfile: Dockerfile
     image: "eth2_ws_server"
+    # network_mode: host
+    networks:
+      - my-external-network
     volumes:
       - .:/app
     depends_on:
       - redis
     ports:
-      - "0.0.0.0:80:80"
+      - "0.0.0.0:8081:8081"
+
+networks:
+  my-external-network:
+    external: true


### PR DESCRIPTION
WIP.  an eventual replacement of @chainsafe/beacon-state-upload

based on convo had here:
https://discord.com/channels/593655374469660673/593655641445367808/845030101501870120

so far:
added ws_state to the standard API response

TODO:
allow user input of `block_root:epoch` to the API from which to base the ws state fetch